### PR TITLE
Add ansible-lint and update sonar-scanner-cli source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,18 @@ ENV SONAR_SCANNER_OPTS="-Xmx512m -Dsonar.host.url=https://sonarqube.digital.home
 ENV PATH=/opt/sonar-scanner-${SONAR_SCANNER_VER}/bin:${PATH}
 
 RUN yum clean all && \
-    yum update -y && \
-    yum install -y wget curl unzip git && \
+    yum update -y --exclude filesystem* && \
+    yum install -y wget curl unzip git epel-release && \
+    yum install -y python-pip && \
     yum clean all && \
     rpm --rebuilddb
 
+#for ansible plugins
+RUN pip install ansible-lint
+
 #Install sonar-scanner
 RUN wget -O /tmp/sonar-scanner-cli-${SONAR_SCANNER_VER}.zip \
-    https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VER}.zip && \
+    https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VER}.zip && \
     unzip /tmp/sonar-scanner-cli-${SONAR_SCANNER_VER}.zip -d /opt/ && \
     rm -rf /tmp/sonar-scanner-cli-${SONAR_SCANNER_VER}.zip
 


### PR DESCRIPTION
This is needed to use the Ansible Lint SonarQube plugin.
Also updating the source URL for Sonar Scanner.